### PR TITLE
Fix the CI pipeline

### DIFF
--- a/.github/workflows/build-decoder.yml
+++ b/.github/workflows/build-decoder.yml
@@ -38,7 +38,7 @@ jobs:
           Invoke-CMakeNativeBatchInstall ./build/windows ./install/windows -Architectures x86,x64,arm64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}-${{ runner.os }}-${{ env.BUILD_TYPE }}
           path: ${{ github.workspace }}/install/**
@@ -74,7 +74,7 @@ jobs:
           Invoke-CMakeAndroidBatchInstall ./build/android ./install/android -AndroidAbis armeabi-v7a, arm64-v8a, x86, x86_64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}-${{ runner.os }}-${{ env.BUILD_TYPE }}
           path: ${{ github.workspace }}/install/**
@@ -107,7 +107,7 @@ jobs:
           Invoke-CMakeAppleBatchInstall ./build/apple ./install/apple -Platforms MAC_CATALYST,MAC_CATALYST_ARM64 -Merge catalyst
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}-${{ runner.os }}-${{ env.BUILD_TYPE }}
           path: ${{ github.workspace }}/install/**
@@ -145,7 +145,7 @@ jobs:
           Invoke-CMakeInstall ./build/browser-wasm ./install/browser-wasm
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}-wasm-${{ env.BUILD_TYPE }}
           path: ${{ github.workspace }}/install/**
@@ -165,10 +165,10 @@ jobs:
           dotnet-version: 6.0.x
 
       - name: Authenticate with nuget
-        run: dotnet nuget add source --username KiruyaMomochi --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/KiruyaMomochi/index.json"
+        run: dotnet nuget add source --username KiruyaMomochi --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Kiruya/index.json"
 
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Copy dlls to install
         run: |
@@ -179,7 +179,7 @@ jobs:
           find . -type f -exec file '{}' ';'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}-${{ env.BUILD_TYPE }}
           path: ${{ github.workspace }}/install/**
@@ -188,7 +188,7 @@ jobs:
         run: nuget/build.ps1 -OutputDir ${{ github.workspace }}/package
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}-NuGet
           path: "${{ github.workspace }}/package"

--- a/.github/workflows/build-decoder.yml
+++ b/.github/workflows/build-decoder.yml
@@ -2,7 +2,7 @@ name: Texture2DDecoderNative
 
 on:
   push:
-    branches: [main, fix-ci]
+    branches: [main]
     paths:
       - "Texture2DDecoderNative/**"
       - '.github/workflows/build-decoder.yml'
@@ -165,7 +165,7 @@ jobs:
           dotnet-version: 6.0.x
 
       - name: Authenticate with nuget
-        run: dotnet nuget add source --username Lego-Fan9 --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Lego-Fan9/index.json"
+        run: dotnet nuget add source --username KiruyaMomochi --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/KiruyaMomochi/index.json"
 
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-decoder.yml
+++ b/.github/workflows/build-decoder.yml
@@ -2,7 +2,7 @@ name: Texture2DDecoderNative
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix-ci]
     paths:
       - "Texture2DDecoderNative/**"
       - '.github/workflows/build-decoder.yml'
@@ -165,7 +165,7 @@ jobs:
           dotnet-version: 6.0.x
 
       - name: Authenticate with nuget
-        run: dotnet nuget add source --username KiruyaMomochi --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Kiruya/index.json"
+        run: dotnet nuget add source --username Lego-Fan9 --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Lego-Fan9/index.json"
 
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -2,7 +2,7 @@ name: Texture2DDecoderWrapper
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix-ci]
     paths:
       - "Texture2DDecoderWrapper/**"
       - '.github/workflows/build-wrapper.yml'
@@ -27,7 +27,7 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Authenticate with nuget
-        run: dotnet nuget add source --username KiruyaMomochi --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Kiruya/index.json"
+        run: dotnet nuget add source --username Lego-Fan9 --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Lego-Fan9/index.json"
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Authenticate with nuget
-        run: dotnet nuget add source --username KiruyaMomochi --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/KiruyaMomochi/index.json"
+        run: dotnet nuget add source --username KiruyaMomochi --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Kiruya/index.json"
 
       - name: Restore dependencies
         run: dotnet restore
@@ -41,7 +41,7 @@ jobs:
           dotnet pack --configuration ${{ env.BUILD_TYPE }} --no-restore --output ${{ github.workspace }}/package --version-suffix $Suffix
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}-NuGet
           path: "${{ github.workspace }}/package"

--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -2,7 +2,7 @@ name: Texture2DDecoderWrapper
 
 on:
   push:
-    branches: [main, fix-ci]
+    branches: [main]
     paths:
       - "Texture2DDecoderWrapper/**"
       - '.github/workflows/build-wrapper.yml'
@@ -27,7 +27,7 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Authenticate with nuget
-        run: dotnet nuget add source --username Lego-Fan9 --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Lego-Fan9/index.json"
+        run: dotnet nuget add source --username KiruyaMomochi --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/KiruyaMomochi/index.json"
 
       - name: Restore dependencies
         run: dotnet restore

--- a/Texture2DDecoderWrapper/Texture2DDecoderWrapper.csproj
+++ b/Texture2DDecoderWrapper/Texture2DDecoderWrapper.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>Example.Texture2DDecoder</PackageId>
+    <PackageId>Kyaru.Texture2DDecoder</PackageId>
     <PackageProjectUrl>https://github.com/KiruyaMomochi/Texture2DDecoder</PackageProjectUrl>
     <RepositoryUrl>https://github.com/KiruyaMomochi/Texture2DDecoder</RepositoryUrl>
     <RepositoryType>git</RepositoryType> 

--- a/Texture2DDecoderWrapper/Texture2DDecoderWrapper.csproj
+++ b/Texture2DDecoderWrapper/Texture2DDecoderWrapper.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>Kyaru.Texture2DDecoder</PackageId>
+    <PackageId>Example.Texture2DDecoder</PackageId>
     <PackageProjectUrl>https://github.com/KiruyaMomochi/Texture2DDecoder</PackageProjectUrl>
     <RepositoryUrl>https://github.com/KiruyaMomochi/Texture2DDecoder</RepositoryUrl>
     <RepositoryType>git</RepositoryType> 

--- a/cmake/cmake-helper.psm1
+++ b/cmake/cmake-helper.psm1
@@ -58,13 +58,13 @@ function Get-CMakeNativeArgs {
         ([TargetSystem]::MacOS) {
             switch ($architecture) {
                 'x64' {
-                    '-D', 'CMAKE_OSX_ARCHITECTURES="x86_64"'
+                    '-D', 'CMAKE_OSX_ARCHITECTURES=x86_64'
                 }
                 'arm64' {
-                    '-D', 'CMAKE_OSX_ARCHITECTURES="arm64"'
+                    '-D', 'CMAKE_OSX_ARCHITECTURES=arm64'
                 }
                 'universal' {
-                    '-D', 'CMAKE_OSX_ARCHITECTURES="x86_64;arm64"'
+                    '-D', 'CMAKE_OSX_ARCHITECTURES=x86_64;arm64'
                 }
                 default {
                     throw "Unsupported architecture: $architecture for $TargetSystem"

--- a/cmake/setup-emsdk.ps1
+++ b/cmake/setup-emsdk.ps1
@@ -5,15 +5,7 @@ param (
     [string]
     $EmsdkPath
 )
-$dotnetVersion = (dotnet --version).Split('.')
-if ($dotnetVersion[-1].Length -eq 3) {
-$dotnetVersion[-1] = $dotnetVersion[-1][0]
-}
-$dotnetVersion = $dotnetVersion -join '.'
-$emsdkVersion = (Invoke-WebRequest https://github.com/dotnet/runtime/raw/v$dotnetVersion/src/mono/wasm/emscripten-version.txt).Content
-
-Write-Host "Using emsdk $emsdkVersion for dotnet $dotnetVersion"
 
 Set-Location $EmsdkPath
-./emsdk install $emsdkVersion
-./emsdk activate $emsdkVersion
+./emsdk install latest
+./emsdk activate latest

--- a/nuget/Directory.Build.props
+++ b/nuget/Directory.Build.props
@@ -20,7 +20,7 @@
             $(MSBuildProjectName) Native library for $(LibraryName).
         </Description>
 
-        <PackageId>Kyaru.$(LibraryName).$(MSBuildProjectName)</PackageId>
+        <PackageId>Example.$(LibraryName).$(MSBuildProjectName)</PackageId>
         <TargetFramework>netstandard1.0</TargetFramework>
 
         <!-- https://github.com/NuGet/Home/issues/4254 -->

--- a/nuget/Directory.Build.props
+++ b/nuget/Directory.Build.props
@@ -20,7 +20,7 @@
             $(MSBuildProjectName) Native library for $(LibraryName).
         </Description>
 
-        <PackageId>Example.$(LibraryName).$(MSBuildProjectName)</PackageId>
+        <PackageId>Kyaru.$(LibraryName).$(MSBuildProjectName)</PackageId>
         <TargetFramework>netstandard1.0</TargetFramework>
 
         <!-- https://github.com/NuGet/Home/issues/4254 -->


### PR DESCRIPTION
This pull request fixes the CI/CD pipeline as it has aged a bit.

All changes have been used to make Example.Texture2DDecoder packages on https://github.com/Lego-Fan9/Texture2DDecoder. The workflow runs for these can be seen at https://github.com/Lego-Fan9/Texture2DDecoder/actions/runs/20839297794 and https://github.com/Lego-Fan9/Texture2DDecoder/actions/runs/20839297759 please note that the main branch of that repository was used to build the Lego-Fan9.Texture2DDecoder packages and does not match the source used here.

## Changes:
* Updated actions/upload-artifact and actions/download-artifact from v3 to v4
  * This is required by GitHub
* Remove some quotation marks from cmake/cmake-helper.psm1 function Get-CMakeNativeArgs when setting MacOS flags
  * I assume Apple changed something here, it was erroring with them and doesn't without
* Update the ios-cmake submodule
  * The version used before was trying to use an iOS SDK no longer in XCode
* Rework how cmake/setup-emsdk.ps1 gets a version to install
  * the dotnet/runtime repo no longer has src/mono/wasm/emscripten-version.txt so I have it installing the latest version. I was unsure if it should be a pinned version or not