### PR TITLE
Add linux-arm64 support

### DIFF
--- a/.github/workflows/build-decoder.yml
+++ b/.github/workflows/build-decoder.yml
@@ -50,13 +50,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install multilib
+      - name: Install gcc libraries
         if: runner.os == 'Linux'
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install -yq gcc-multilib g++-multilib
-
+          sudo apt install -yq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-13-aarch64-linux-gnu g++-13-aarch64-linux-gnu
+      
       - name: Install Ninja
         run: |
           sudo apt install -yq ninja-build
@@ -64,13 +65,13 @@ jobs:
       - name: Configure and Build
         run: |
           Import-Module (Join-Path '${{ github.workspace }}' cmake 'cmake-helper.psm1')
-          Invoke-CMakeNativeBatchBuild ${{ env.PROJECT_NAME }} ./build/linux -Architectures x86, x64
+          Invoke-CMakeNativeBatchBuild ${{ env.PROJECT_NAME }} ./build/linux -Architectures x86, x64, arm64
           Invoke-CMakeAndroidBatchBuild ${{ env.PROJECT_NAME }} ./build/android -Generator Ninja -AndroidAbis armeabi-v7a, arm64-v8a, x86, x86_64 -NdkHome $env:ANDROID_NDK_LATEST_HOME -NdkToolchain
 
       - name: Install
         run: |
           Import-Module (Join-Path '${{ github.workspace }}' cmake 'cmake-helper.psm1')
-          Invoke-CMakeNativeBatchInstall ./build/linux ./install/linux -Architectures x86, x64
+          Invoke-CMakeNativeBatchInstall ./build/linux ./install/linux -Architectures x86, x64, arm64
           Invoke-CMakeAndroidBatchInstall ./build/android ./install/android -AndroidAbis armeabi-v7a, arm64-v8a, x86, x86_64
 
       - name: Upload artifact

--- a/cmake/cmake-helper.psm1
+++ b/cmake/cmake-helper.psm1
@@ -77,6 +77,12 @@ function Get-CMakeNativeArgs {
                     '-DCMAKE_CXX_FLAGS=-m32', '-DCMAKE_C_FLAGS=-m32'
                 }
                 'x64' {}
+                'arm64' {
+                    '-DCMAKE_SYSTEM_NAME=Linux', 
+                    '-DCMAKE_SYSTEM_PROCESSOR=aarch64', 
+                    '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc', 
+                    '-DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++'
+                }
                 default {
                     throw "Unsupported architecture: $architecture for $TargetSystem"
                 }

--- a/nuget/Linux.csproj
+++ b/nuget/Linux.csproj
@@ -6,5 +6,8 @@
         <PackNativeLibrary Include="../install/linux-x86/lib/libTexture2DDecoderNative.so">
             <Link>runtimes/linux-x86/native/libTexture2DDecoderNative.so</Link>
         </PackNativeLibrary>
+        <PackNativeLibrary Include="../install/linux-arm64/lib/libTexture2DDecoderNative.so">
+            <Link>runtimes/linux-arm64/native/libTexture2DDecoderNative.so</Link>
+        </PackNativeLibrary>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds support for Linux-arm64 by adding the necessary shared library to runtimes/linux-arm64/native/libTexture2DDecoderNative.so

Please note that https://github.com/KiruyaMomochi/Texture2DDecoder/pull/3 should be merged first as it fixes the CI/CD pipeline